### PR TITLE
Remove support for “tail” and replace with split

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,15 +14,14 @@ module.exports = function (options) {
 
       params = params || {};
 
-      var x, param;
+      var key, param;
       for (var i = 0; i < keys.length; i++) {
-        param = m[x = i + 1];
+        key = keys[i];
+        param = m[i + 1];
         if (!param) continue;
-        params[keys[i].name] = decodeParam(param);
+        params[key.name] = decodeParam(param);
+        if (key.repeat) params[key.name] = params[key.name].split(key.delimiter)
       }
-
-      var tail = m.slice(++x).join('/');
-      if (tail) params.tail = tail;
 
       return params;
     }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "repository": "expressjs/path-match",
   "dependencies": {
-    "path-to-regexp": "*"
+    "path-to-regexp": "~0.2.1"
   },
   "devDependencies": {
     "mocha": "*"

--- a/test/index.js
+++ b/test/index.js
@@ -31,6 +31,7 @@ it('/:a/b/:c', function () {
 
 describe('/:a/b/:c?', function () {
   var match = route('/:a/b/:c?');
+
   it('/a/b/c', function () {
     var params = match('/a/b/c');
     assert.deepEqual(params, {
@@ -50,12 +51,20 @@ describe('/:a/b/:c?', function () {
 describe('/:a/:b/:c*', function () {
   var match = route('/:a/:b/:c*')
 
+  it('/a/b', function () {
+    var params = match('/a/b')
+    assert.deepEqual(params, {
+      a: 'a',
+      b: 'b',
+    })
+  })
+
   it('/a/b/c', function () {
     var params = match('/a/b/c')
     assert.deepEqual(params, {
       a: 'a',
       b: 'b',
-      c: 'c',
+      c: ['c'],
     })
   })
 
@@ -64,8 +73,7 @@ describe('/:a/:b/:c*', function () {
     assert.deepEqual(params, {
       a: 'a',
       b: 'b',
-      c: 'c',
-      tail: '/d'
+      c: ['c', 'd']
     })
   })
 
@@ -74,8 +82,43 @@ describe('/:a/:b/:c*', function () {
     assert.deepEqual(params, {
       a: 'a',
       b: 'b',
-      c: 'c',
-      tail: '/d/e'
+      c: ['c', 'd', 'e']
+    })
+  })
+})
+
+describe('/:a/:b/:c+', function () {
+  var match = route('/:a/:b/:c+')
+
+  it('/a/b', function () {
+    var params = match('/a/b')
+    assert.deepEqual(params, false)
+  })
+
+  it('/a/b/c', function () {
+    var params = match('/a/b/c')
+    assert.deepEqual(params, {
+      a: 'a',
+      b: 'b',
+      c: ['c'],
+    })
+  })
+
+  it('/a/b/c/d', function () {
+    var params = match('/a/b/c/d')
+    assert.deepEqual(params, {
+      a: 'a',
+      b: 'b',
+      c: ['c', 'd']
+    })
+  })
+
+  it('/a/b/c/d/e', function () {
+    var params = match('/a/b/c/d/e')
+    assert.deepEqual(params, {
+      a: 'a',
+      b: 'b',
+      c: ['c', 'd', 'e']
     })
   })
 })


### PR DESCRIPTION
- The tail property looks kind of flimsy and its unnecessary with the latest `path-to-regexp`
- Splits repeat parameter names by their delimiter
- Closes component/path-to-regexp#26
