### PR TITLE
Replace http-errors dependency with straightforward Error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 
 var pathToRegexp = require('path-to-regexp');
-var createError = require('http-errors');
 
 module.exports = function (options) {
   options = options || {};
@@ -33,6 +32,6 @@ function decodeParam(param) {
   try {
     return decodeURIComponent(param);
   } catch (_) {
-    throw createError(400, 'failed to decode param "' + param + '"');
+    throw new Error('failed to decode param "' + param + '"');
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "license": "MIT",
   "repository": "pillarjs/path-match",
   "dependencies": {
-    "http-errors": "~1.2.0",
     "path-to-regexp": "1"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -10,7 +10,6 @@ it('/%%%', function () {
     throw new Error('jklajsldkfjasdf');
   } catch (err) {
     assert(~err.message.indexOf('"%%%"'));
-    assert.equal(err.status, 400);
   }
 })
 


### PR DESCRIPTION
* package is so simple that there is no need to use more
  dependencies (that have their own dependencies, etc.) than it's
  necessary to reach the goal; let's keep it simple and smaller
* throwing super specifc HTTP-based error with additional properties
  isn't really this package concern; it's up to end user to catch it and
  coerce to whatever is required by design (what if I want it to be HTTP
  500, not HTTP 400?)