### PR TITLE
Add TypeScript definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,10 @@
 *.gz
 
 node_modules
+
+# Nyc directories
 coverage
+.nyc_output
+
+# Compiled test file
+test/index.js

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,7 @@ declare namespace pathMatch {
    * otherwise it returns a paramName -> paramValue map of the matched
    * parameters
    */
-  export type MatchFunction = (pathname: string, params?: object) => false | ParamsMap;
+  export type MatchFunction = (pathname: string, params?: ParamsMap) => false | ParamsMap;
 
   /**
    * Get a match function for the given path pattern

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,30 @@
+import {ParseOptions, Path, RegExpOptions} from "path-to-regexp";
+
+/**
+ * Get a route function configured with the given options
+ * @param options Path matching options passed to path-to-regexp
+ */
+declare function pathMatch (options?: RegExpOptions & ParseOptions): pathMatch.RouteFunction;
+
+declare namespace pathMatch {
+
+  export type ParamsMap = {
+      [key: string]: string | string[];
+  }
+
+  /**
+   * Matches a path agains its path pattern
+   * @returns false if the given path didn't match the function's path pattern,
+   * otherwise it returns a paramName -> paramValue map of the matched
+   * parameters
+   */
+  export type MatchFunction = (pathname: string, params?: object) => false | ParamsMap;
+
+  /**
+   * Get a match function for the given path pattern
+   */
+  export type RouteFunction = (path: Path) => MatchFunction;
+
+}
+
+export = pathMatch;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import {ParseOptions, Path, RegExpOptions} from "path-to-regexp";
+import { ParseOptions, Path, RegExpOptions } from 'path-to-regexp';
 
 /**
  * Get a route function configured with the given options
@@ -7,9 +7,8 @@ import {ParseOptions, Path, RegExpOptions} from "path-to-regexp";
 declare function pathMatch (options?: RegExpOptions & ParseOptions): pathMatch.RouteFunction;
 
 declare namespace pathMatch {
-
   export type ParamsMap = {
-      [key: string]: string | string[];
+    [key: string]: string | string[];
   }
 
   /**
@@ -24,7 +23,6 @@ declare namespace pathMatch {
    * Get a match function for the given path pattern
    */
   export type RouteFunction = (path: Path) => MatchFunction;
-
 }
 
 export = pathMatch;

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
   "license": "MIT",
   "repository": "pillarjs/path-match",
   "dependencies": {
-    "http-errors": "~1.4.0",
-    "path-to-regexp": "^1.0.0"
+    "http-errors": "~1.6.1",
+    "path-to-regexp": "^1.7.0"
   },
   "devDependencies": {
-    "istanbul": "^0.4.2",
-    "mocha": "^2.0.0"
+    "istanbul": "^0.4.5",
+    "mocha": "^3.2.0"
   },
   "scripts": {
     "test": "mocha --reporter spec",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
   },
   "files": [
-    "index.js"
-  ]
+    "index.js",
+    "index.d.ts"
+  ],
+  "typings": "index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -27,15 +27,14 @@
   "devDependencies": {
     "@types/mocha": "^2.2.40",
     "@types/node": "^7.0.12",
-    "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
-    "ts-node": "^3.0.2",
+    "nyc": "^10.2.0",
     "typescript": "^2.2.2"
   },
   "scripts": {
-    "test": "mocha --require ts-node/register -R spec test/index.ts",
-    "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require ts-node/register -R dot test/index.ts",
-    "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require ts-node/register -R dot test/index.ts"
+    "test": "tsc test/index.ts && mocha -R spec test/index.js",
+    "test-cov": "nyc npm test",
+    "test-travis": "nyc --reporter=lcov npm test"
   },
   "files": [
     "index.js",

--- a/package.json
+++ b/package.json
@@ -25,13 +25,17 @@
     "path-to-regexp": "^1.7.0"
   },
   "devDependencies": {
+    "@types/mocha": "^2.2.40",
+    "@types/node": "^7.0.12",
     "istanbul": "^0.4.5",
-    "mocha": "^3.2.0"
+    "mocha": "^3.2.0",
+    "ts-node": "^3.0.2",
+    "typescript": "^2.2.2"
   },
   "scripts": {
-    "test": "mocha --reporter spec",
-    "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
-    "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+    "test": "mocha --require ts-node/register -R spec test/index.ts",
+    "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require ts-node/register -R dot test/index.ts",
+    "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require ts-node/register -R dot test/index.ts"
   },
   "files": [
     "index.js",

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,9 +1,9 @@
 
 import assert = require('assert');
 
-import matchPath = require('..');
+import pathMatch = require('..');
 
-var route = matchPath();
+var route = pathMatch();
 
 it('/%%%', function () {
   var match = route('/:a');

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,7 +1,9 @@
 
-var assert = require('assert');
+import assert = require('assert');
 
-var route = require('..')();
+import matchPath = require('..');
+
+var route = matchPath();
 
 it('/%%%', function () {
   var match = route('/:a');


### PR DESCRIPTION
(Also updates dependencies since the david-dm badge is showing them as out-of-date)

A couple of notes:

* the signature for `MatchFunction` is not 100% correct for a couple of reasons:
  * if I pass `true` (or a string, a non-zero number etc) as second argument, I don't get back a `ParamsObject`, but rather the same thing I passed in. I would qualify this as an "undefined behaviour" of the function when it's invoked with a second argument that doesn't make much sense, hence my choice to type the second argument as [`object`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type)
  * I typed its return value as a `string -> string | string[]` map, even though, if I pass as second argument a "complex object", I get in return that object decorated with the parameters keys/values. The only way to type it correctly would be to use the `object` type or even `any`, but I thought that in the majority of use cases the `ParamsMap` type would be more useful

* as per the conversation in pillarjs/path-to-regexp#72, I "ported" the test file to TypeScript and used `ts-node` to run it (adding the appropriate dev-dependencies)

Hope it's a welcome contribution 🙂 